### PR TITLE
Fix parsing of AMQP URI host:port

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net"
 	"net/url"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -53,7 +55,12 @@ func Dial(amqp string) (me *Connection, err error) {
 		return
 	}
 
-	fmt.Sscanf(u.Host, "%s:%d", &host, &port)
+	if toks := strings.Split(u.Host, ":"); len(toks) == 2 {
+		host = toks[0]
+		if port32, err := strconv.ParseInt(toks[1], 10, 32); err == nil {
+			port = int(port32)
+		}
+	}
 
 	hostport := fmt.Sprintf("%s:%d", host, port)
 


### PR DESCRIPTION
fmt.Sscanf is very greedy on `%s`; it will gobble up anything that isn't whitespace. Consequently, the Sscanf on u.Host doesn't properly split out the port. See [this example](http://play.golang.org/p/lej33QlZp8) for a demonstration.
