### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: go
 
 before_install:
  - sudo service rabbitmq-server start
- - sudo rabbitmqctl add_vhost /                               || true
- - sudo rabbitmqctl add_user guest guest                      || true
- - sudo rabbitmqctl set_permissions -p / guest ".*" ".*" ".*" || true
+ - sleep 1
+ - sudo service rabbitmq-server status
+
+env:
+ - AMQP_URL="amqp://guest:guest@127.0.0.1:5672/"
 
 before_script:
- - export AMQP_URL=amqp://guest:guest@127.0.0.1:5672/
  - sh -c "sleep 120 && killall -QUIT amqp.test" &


### PR DESCRIPTION
A brief explanation of each change:
- RabbitMQ will add default vhost, user and permission on boot if they do not exist
- Travis CI has a built-in way of exporting env variables
- It is usually a good idea to quote env variable values. No difference as far as bash goes but safer from the YAML parsing standpoint
- Added a line that makes sure rabbitmq is running after 1 second (just in case)
