### PR TITLE
Clean up in the exchange redeclaration test

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -663,6 +663,7 @@ func TestExchangeDeclarePrecondition(t *testing.T) {
 	c1 := integrationConnection(t, "exchange-double-declare")
 	c2 := integrationConnection(t, "exchange-double-declare-cleanup")
 	if c1 != nil {
+		defer c2.Close()
 		ch, err := c1.Channel()
 		if err != nil {
 			t.Fatalf("Create channel")


### PR DESCRIPTION
After a channel-level exception (406) in the test, we can no longer use
the same channel so we clean up using a different one.

I apologize for extra lines in the diff, running `go fmt` still leaves them changed.
