### PR TITLE
durable=true with autodelete=true makes sense for exchanges

### DIFF
--- a/examples/simple-consumer/consumer.go
+++ b/examples/simple-consumer/consumer.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	uri          = flag.String("uri", "amqp://guest:guest@localhost:5672/", "AMQP URI")
-	exchange     = flag.String("exchange", "test-exchange", "Durable AMQP exchange name")
+	exchange     = flag.String("exchange", "test-exchange", "Durable, non-auto-deleted AMQP exchange name")
 	exchangeType = flag.String("exchange-type", "direct", "Exchange type - direct|fanout|topic|x-custom")
 	queue        = flag.String("queue", "test-queue", "Ephemeral AMQP queue name")
 	bindingKey   = flag.String("key", "test-key", "AMQP binding key")
@@ -78,23 +78,25 @@ func NewConsumer(amqpURI, exchange, exchangeType, queue, key, ctag string) (*Con
 
 	log.Printf("got Channel, declaring Exchange (%s)", exchange)
 	if err = c.channel.ExchangeDeclare(
-		exchange,          // name of the exchange
-		exchangeType,      // type
-		amqp.UntilDeleted, // lifetime = durable
-		false,             // internal
-		false,             // noWait
-		nil,               // arguments
+		exchange,     // name of the exchange
+		exchangeType, // type
+		true,         // durable
+		false,        // delete when complete
+		false,        // internal
+		false,        // noWait
+		nil,          // arguments
 	); err != nil {
 		return nil, fmt.Errorf("Exchange Declare: %s", err)
 	}
 
 	log.Printf("declared Exchange, declaring Queue (%s)", queue)
 	state, err := c.channel.QueueDeclare(
-		queue,            // name of the queue
-		amqp.UntilUnused, // lifetime = auto-delete
-		false,            // exclusive
-		false,            // noWait
-		nil,              // arguments
+		queue, // name of the queue
+		true,  // durable
+		false, // delete when usused
+		false, // exclusive
+		false, // noWait
+		nil,   // arguments
 	)
 	if err != nil {
 		return nil, fmt.Errorf("Queue Declare: %s", err)

--- a/examples/simple-producer/producer.go
+++ b/examples/simple-producer/producer.go
@@ -51,12 +51,13 @@ func publish(amqpURI, exchange, exchangeType, routingKey, body string, reliable 
 
 	log.Printf("got Channel, declaring %q Exchange (%s)", exchangeType, exchange)
 	if err := channel.ExchangeDeclare(
-		exchange,          // name
-		exchangeType,      // type
-		amqp.UntilDeleted, // lifetime = durable
-		false,             // internal
-		false,             // noWait
-		nil,               // arguments
+		exchange,     // name
+		exchangeType, // type
+		true,         // durable
+		false,        // auto-deleted
+		false,        // internal
+		false,        // noWait
+		nil,          // arguments
 	); err != nil {
 		return fmt.Errorf("Exchange Declare: %s", err)
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -26,11 +26,11 @@ func ExampleChannel_Confirm_bridge() {
 		log.Fatalf("channel.open source: %s", err)
 	}
 
-	if err := chs.ExchangeDeclare("log", "topic", amqp.UntilDeleted, false, false, nil); err != nil {
+	if err := chs.ExchangeDeclare("log", "topic", true, false, false, false, nil); err != nil {
 		log.Fatalf("exchange.declare destination: %s", err)
 	}
 
-	if _, err := chs.QueueDeclare("remote-tee", amqp.UntilUnused, false, false, nil); err != nil {
+	if _, err := chs.QueueDeclare("remote-tee", true, true, false, false, nil); err != nil {
 		log.Fatalf("queue.declare source: %s", err)
 	}
 
@@ -55,7 +55,7 @@ func ExampleChannel_Confirm_bridge() {
 		log.Fatalf("channel.open destination: %s", err)
 	}
 
-	if err := chd.ExchangeDeclare("log", "topic", amqp.UntilDeleted, false, false, nil); err != nil {
+	if err := chd.ExchangeDeclare("log", "topic", true, false, false, false, nil); err != nil {
 		log.Fatalf("exchange.declare destination: %s", err)
 	}
 
@@ -129,7 +129,7 @@ func ExampleChannel_Consume() {
 	// are the same.  This is part of AMQP being a programmable messaging model.
 	//
 	// See the Channel.Publish example for the complimentary declare.
-	err = c.ExchangeDeclare("logs", "topic", amqp.UntilDeleted, false, false, nil)
+	err = c.ExchangeDeclare("logs", "topic", true, false, false, false, nil)
 	if err != nil {
 		log.Fatal("exchange.declare: %s", err)
 	}
@@ -147,7 +147,7 @@ func ExampleChannel_Consume() {
 	}
 
 	for _, b := range bindings {
-		_, err = c.QueueDeclare(b.queue, amqp.UntilDeleted, false, false, nil)
+		_, err = c.QueueDeclare(b.queue, true, false, false, false, nil)
 		if err != nil {
 			log.Fatal("queue.declare: %s", err)
 		}
@@ -251,7 +251,7 @@ func ExampleChannel_Publish() {
 	// are the same.  This is part of AMQP being a programmable messaging model.
 	//
 	// See the Channel.Consume example for the complimentary declare.
-	err = c.ExchangeDeclare("logs", "topic", amqp.UntilDeleted, false, false, nil)
+	err = c.ExchangeDeclare("logs", "topic", true, false, false, false, nil)
 	if err != nil {
 		log.Fatal("exchange.declare: %s", err)
 	}

--- a/lib_test.go
+++ b/lib_test.go
@@ -117,7 +117,7 @@ func integrationConnection(t *testing.T, name string) *Connection {
 func integrationQueue(t *testing.T, name string) (*Connection, *Channel) {
 	if conn := integrationConnection(t, name); conn != nil {
 		if channel, err := conn.Channel(); err == nil {
-			if _, err = channel.QueueDeclare(name, UntilUnused, false, false, nil); err == nil {
+			if _, err = channel.QueueDeclare(name, false, true, false, false, nil); err == nil {
 				return conn, channel
 			}
 		}

--- a/reconnect_test.go
+++ b/reconnect_test.go
@@ -18,7 +18,7 @@ func setup(url, queue string) (*amqp.Connection, *amqp.Channel, error) {
 		return nil, nil, err
 	}
 
-	if _, err := ch.QueueDeclare(queue, amqp.UntilUnused, false, false, nil); err != nil {
+	if _, err := ch.QueueDeclare(queue, false, true, false, false, nil); err != nil {
 		return nil, nil, err
 	}
 

--- a/types.go
+++ b/types.go
@@ -64,8 +64,9 @@ type properties struct {
 
 // DeliveryMode.  Transient means higher throughput but messages will not be
 // restored on broker restart.  The delivery mode of publishings is unrelated
-// to the lifetime of the queues they reside on.  Transient messages will not
-// be restored in queues with a lifetime UntilDeleted on server restart.
+// to the durability of the queues they reside on.  Transient messages will
+// not be restored to durable queues, persistent messages will be restored to
+// durable queues and lost on non-durable queues during server restart.
 //
 // This remains typed as uint8 to match Publishing.DeliveryMode.  Other
 // delivery modes specific to custom queue implementations are not enumerated
@@ -94,41 +95,6 @@ const (
 	flagAppId           = 0x0008
 	flagReserved1       = 0x0004
 )
-
-// A library type that makes it simpler to reason about the possible Durable
-// and AutoDelete fields that make sense for a Queue or Exchange.  This avoids
-// the possible combination of durable=true, autoDelete=true.
-type Lifetime int
-
-const (
-	UntilDeleted         Lifetime = iota // durable
-	UntilServerRestarted                 // not durable, not auto-delete
-	UntilUnused                          // auto-delete
-)
-
-func (me *Lifetime) durable() bool {
-	switch *me {
-	case UntilDeleted:
-		return true
-	case UntilServerRestarted:
-		return false
-	case UntilUnused:
-		return false
-	}
-	panic("unknown lifetime")
-}
-
-func (me *Lifetime) autoDelete() bool {
-	switch *me {
-	case UntilDeleted:
-		return false
-	case UntilServerRestarted:
-		return false
-	case UntilUnused:
-		return true
-	}
-	panic("unknown lifetime")
-}
 
 // Current state of the queue on the server returned from Channel.QueueDeclare or
 // Channel.QueueInspect.


### PR DESCRIPTION
ExchangeDeclare needs to have boolean parameters for the two flags instead of the Lifetime parameter, because for exchanges this combination makes sense. If such an exchange is connected to a queue that has durable=true and autodelete=false, then the exchange is not automatically deleted until the queue is gone and it can survive a server restart.
