### PR TITLE
Application testable Delivery - API Change

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1391,3 +1391,48 @@ func (me *Channel) Recover(requeue bool) error {
 		&basicRecoverOk{},
 	)
 }
+
+/*
+Ack acknowledges a delivery by its delivery tag when having been consumed with
+Channel.Consume or Channel.Get.
+
+Ack acknowledges all message received prior to the delivery tag when multiple
+is true.
+
+See also Delivery.Ack
+*/
+func (me *Channel) Ack(tag uint64, multiple bool) error {
+	return me.send(me, &basicAck{
+		DeliveryTag: tag,
+		Multiple:    multiple,
+	})
+}
+
+/*
+Nack negatively acknowledges a delivery by its delivery tag.  Prefer this
+method to notify the server that you were not able to process this delivery and
+it must be redelivered or dropped.
+
+See also Delivery.Nack
+*/
+func (me *Channel) Nack(tag uint64, multiple bool, requeue bool) error {
+	return me.send(me, &basicNack{
+		DeliveryTag: tag,
+		Multiple:    multiple,
+		Requeue:     requeue,
+	})
+}
+
+/*
+Reject negatively acknowledges a delivery by its delivery tag.  Prefer Nack
+over Reject when communicating with a RabbitMQ server because you can Nack
+multiple messages, reducing the amount of protocol messages to exchange.
+
+See also Delivery.Reject
+*/
+func (me *Channel) Reject(tag uint64, requeue bool) error {
+	return me.send(me, &basicReject{
+		DeliveryTag: tag,
+		Requeue:     requeue,
+	})
+}


### PR DESCRIPTION
References #64 
- Add Ack/Nack/Reject to the Channel
- Add Delivery.Acknowledger interface delegating to the channel
- Drop Delivery.Cancel

By using an Acknowledger delegate, it remains possible to multiplex
deliveries from multiple channels to the same handler without requiring
the application to keep a reverse mapping from delivery back to the
source channel for the common case of Acks.

Application tests can now simulate deliveries, and track acknowledgments
per source channel via a custom implementation.

Remove the `Cancel` delegate in Delivery.  Use the Channel directly to
cancel a subscription.

To handle Cancel, including other richer interactions with the Channel
in application consumers, the channel reference should be passed along
with the delivery in an application specific type to the consumer.
