### PR TITLE
Publish now returns the publishing sequence number

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1215,12 +1215,12 @@ for every publishing you publish, only exiting when all publishings are
 accounted for.
 
 */
-func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg Publishing) error {
+func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg Publishing) (uint64, error) {
 	me.m.Lock()
 	defer me.m.Unlock()
 
 	if err := msg.Headers.Validate(); err != nil {
-		return err
+		return 0, err
 	}
 
 	if err := me.send(me, &basicPublish{
@@ -1245,7 +1245,7 @@ func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg 
 			AppId:           msg.AppId,
 		},
 	}); err != nil {
-		return err
+		return 0, err
 	}
 
 	me.publishCounter += 1
@@ -1254,7 +1254,7 @@ func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg 
 		heap.Push(&me.confirms, me.publishCounter)
 	}
 
-	return nil
+	return me.publishCounter, nil
 }
 
 /*


### PR DESCRIPTION
The publishing sequence number is essential to keep track of confirmation ACK, so return it.
I'm aware it introduces an API break though ... (May be wiser to add another method instead) 
