### PR TITLE
add ack while consume the message in the queue

### DIFF
--- a/examples/simple-consumer/consumer.go
+++ b/examples/simple-consumer/consumer.go
@@ -162,6 +162,7 @@ func handle(deliveries <-chan amqp.Delivery, done chan error) {
 			d.DeliveryTag,
 			d.Body,
 		)
+		d.Ack(true)
 	}
 	log.Printf("handle: deliveries channel closed")
 	done <- nil


### PR DESCRIPTION
Is there missing the ack action while I consumed the message? 
