### PR TITLE
Added support for cert-only login without user and password

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -30,8 +30,21 @@ func (me *PlainAuth) Response() string {
 	return fmt.Sprintf("\000%s\000%s", me.Username, me.Password)
 }
 
+// CertAuth for RabbitMQ-auth-mechanism-ssl.
+type CertAuth struct {
+}
+
+func (me *CertAuth) Mechanism() string {
+	return "EXTERNAL"
+}
+
+func (me *CertAuth) Response() string {
+	return fmt.Sprintf("\000*\000*")
+}
+
 // Finds the first mechanism preferred by the client that the server supports.
 func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth Authentication, ok bool) {
+
 	for _, auth = range client {
 		for _, mech := range serverMechanisms {
 			if auth.Mechanism() == mech {

--- a/connection.go
+++ b/connection.go
@@ -134,6 +134,25 @@ func DialTLS(url string, amqps *tls.Config) (*Connection, error) {
 		Heartbeat:       defaultHeartbeat,
 		TLSClientConfig: amqps,
 	})
+
+}
+
+// DialTLS_CertAuth accepts a string in the AMQP URI format and returns a new
+// Connection over TCP using EXTERNAL auth.  Defaults to a server heartbeat
+// interval of 10 seconds and sets the initial read deadline to 30 seconds.
+//
+// This mechanism is used, when RabbitMQ is configured for EXTERNAL auth with
+// ssl_cert_login plugin for userless/passwordless logons
+//
+// DialTLS_CertAuth uses the provided tls.Config when encountering an amqps://
+// scheme.
+func DialTLS_CertAuth(url string, amqps *tls.Config) (*Connection, error) {
+
+	return DialConfig(url, Config{
+		Heartbeat:       defaultHeartbeat,
+		TLSClientConfig: amqps,
+		SASL:            []Authentication{&CertAuth{}},
+	})
 }
 
 // DialConfig accepts a string in the AMQP URI format and a configuration for


### PR DESCRIPTION
Added new DialTLS_CertAuth function for RabbitMQ configured for EXTERNAL auth with ssl_cert_login plugin for userless/passwordless logons.

As of now, amqp just silently hangs, when server presents authentication metod not supported by amqp (when pickSASLMechanism finds no suitable match). I guess it should bail out with some sort of "No common SASL methods found" message.

Hope this helps,
 best regards.
