### PR TITLE
fix import path "code.google.com/p/go.net/context" => "golang.org/x/net/context" in examples

### DIFF
--- a/examples/pubsub/pubsub.go
+++ b/examples/pubsub/pubsub.go
@@ -15,8 +15,8 @@ import (
 	"log"
 	"os"
 
-	"code.google.com/p/go.net/context"
 	"github.com/streadway/amqp"
+	"golang.org/x/net/context"
 )
 
 var url = flag.String("url", "amqp:///", "AMQP url for both the publisher and subscriber")


### PR DESCRIPTION
The import path has changed.

By the way, you should prefix your "examples" directory with a "_".
Like this: https://github.com/pierrre/imageserver/tree/master/_examples
It prevents automatic installation of your examples in `$GOPATH/bin`.
