### PR TITLE
Prevent a memory leak by stopping the heartbeat ticker

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -474,7 +474,9 @@ func (me *Connection) heartbeater(interval time.Duration, done chan *Error) {
 
 	var sendTicks <-chan time.Time
 	if interval > 0 {
-		sendTicks = time.Tick(interval)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		sendTicks = ticker.C
 	}
 
 	lastSent := time.Now()


### PR DESCRIPTION
Hi!

We were experiencing a huge memory leak in one of our applications. After some profiling we found that the reason was a lot of `Ticker` instances being stored in memory [[0]].

Based on this thread [[1]] and documentation [[2]] a `Ticker` should be stopped in order to release resources.

The memory leak was specially huge because *we were* creating a new connection on every publish, so the number of `Ticker` instances stored in memory increased very fast. Anyway this commit fixes any possible memory leaks caused by this.

Thank you!

[0]: https://trello-attachments.s3.amazonaws.com/4f701989ad3e423648203baf/54ae405067b90caef4b196e0/a8d9edc1a40cc37ea17b14e8bbaa9903/p1QroNLb76.0-public.svg
[1]: https://groups.google.com/forum/#!msg/golang-nuts/Chx1tCs2QGg/KTUJN734unoJ
[2]: http://golang.org/pkg/time/#NewTicker