### PR TITLE
Error out if exclusive and durable are used together

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -7,6 +7,7 @@ package amqp
 
 import (
 	"container/heap"
+	"fmt"
 	"reflect"
 	"sync"
 )
@@ -752,6 +753,10 @@ declared with these parameters and the channel will be closed.
 func (me *Channel) QueueDeclare(name string, durable, autoDelete, exclusive, noWait bool, args Table) (Queue, error) {
 	if err := args.Validate(); err != nil {
 		return Queue{}, err
+	}
+
+	if exclusive && durable {
+		return Queue{}, fmt.Errorf("Invalid settings, can not be exclusive and durable")
 	}
 
 	req := &queueDeclare{


### PR DESCRIPTION
The docs on the function as well as the behavior within Rabbitmq indicate that exclusive implies non-durable and auto-delete.

Yet attempting to use exclusive and durable results in no error, just a non-durable queue available within RabbitMQ.

Better to error out if a user (like myself) attempts this than have them be puzzled until they notice that exclusive implies non-durable.