### PR TITLE
Change timestamp granularity to nanoseconds

### DIFF
--- a/read.go
+++ b/read.go
@@ -140,11 +140,11 @@ func readFloat64(r io.Reader) (v float64, err error) {
 }
 
 func readTimestamp(r io.Reader) (v time.Time, err error) {
-	var sec int64
-	if err = binary.Read(r, binary.BigEndian, &sec); err != nil {
+	var nanoSec int64
+	if err = binary.Read(r, binary.BigEndian, &nanoSec); err != nil {
 		return
 	}
-	return time.Unix(sec, 0), nil
+	return time.Unix(nanoSec, 0), nil
 }
 
 /*

--- a/write.go
+++ b/write.go
@@ -362,7 +362,7 @@ func writeField(w io.Writer, value interface{}) (err error) {
 
 	case time.Time:
 		buf[0] = 'T'
-		binary.BigEndian.PutUint64(buf[1:9], uint64(v.Unix()))
+		binary.BigEndian.PutUint64(buf[1:9], uint64(v.UnixNano()))
 		enc = buf[:9]
 
 	case Table:


### PR DESCRIPTION
** DO NOT MERGE ** Integration tests currently failing..

This changes the granularity of timestamps to be in nanoseconds rather seconds, as we were losing the accuracy in some header fields we were using.