### PR TITLE
go-fuzz fixes

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,16 @@
+// +build gofuzz
+package amqp
+
+import "bytes"
+
+func Fuzz(data []byte) int {
+	r := reader{bytes.NewReader(data)}
+	frame, err := r.ReadFrame()
+	if err != nil {
+		if frame != nil {
+			panic("frame is not nil")
+		}
+		return 0
+	}
+	return 1
+}

--- a/read.go
+++ b/read.go
@@ -67,7 +67,7 @@ func (me *reader) ReadFrame() (frame frame, err error) {
 
 	case frameBody:
 		if frame, err = me.parseBodyFrame(channel, size); err != nil {
-			return
+			return nil, err
 		}
 
 	case frameHeartbeat:
@@ -80,7 +80,7 @@ func (me *reader) ReadFrame() (frame frame, err error) {
 	}
 
 	if _, err = io.ReadFull(me.r, scratch[:1]); err != nil {
-		return
+		return nil, err
 	}
 
 	if scratch[0] != frameEnd {
@@ -426,7 +426,7 @@ func (me *reader) parseBodyFrame(channel uint16, size uint32) (frame frame, err 
 	}
 
 	if _, err = io.ReadFull(me.r, bf.Body); err != nil {
-		return
+		return nil, err
 	}
 
 	return bf, nil

--- a/read.go
+++ b/read.go
@@ -8,6 +8,7 @@ package amqp
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"time"
 )
@@ -431,13 +432,15 @@ func (me *reader) parseBodyFrame(channel uint16, size uint32) (frame frame, err 
 	return bf, nil
 }
 
+var errHeartbeatPayload = errors.New("Heartbeats should not have a payload")
+
 func (me *reader) parseHeartbeatFrame(channel uint16, size uint32) (frame frame, err error) {
 	hf := &heartbeatFrame{
 		ChannelId: channel,
 	}
 
 	if size > 0 {
-		panic("Heartbeats should not have a payload")
+		return nil, errHeartbeatPayload
 	}
 
 	return hf, nil

--- a/read_test.go
+++ b/read_test.go
@@ -1,0 +1,22 @@
+package amqp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGoFuzzCrashers(t *testing.T) {
+	testData := []string{
+		"\b000000",
+		"\x02\x16\x10�[��\t\xbdui�" + "\x10\x01\x00\xff\xbf\xef\xbfｻn\x99\x00\x10r",
+		"\x0300\x00\x00\x00\x040000",
+	}
+
+	for idx, testStr := range testData {
+		r := reader{strings.NewReader(testStr)}
+		frame, err := r.ReadFrame()
+		if err != nil && frame != nil {
+			t.Errorf("%d. frame is not nil: %#v err = %v", idx, frame, err)
+		}
+	}
+}


### PR DESCRIPTION
I spent some time fuzzing the reader.ReadFrame method using go-fuzz. It stumbled upon a few minor crashers, for which I then created unit tests. I then implemented fixes for them. I hope this is useful for you.