### PR TITLE
Added go tip to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.1
   - 1.4
   - 1.5
+  - tip
 
 services:
   - rabbitmq


### PR DESCRIPTION
Hello,
Go v1.6 beta 1 was released today, I've added `tip` to the build matrix so all future go releases will be automatically tested without updating the `.travis.yml` file
