### PR TITLE
Expose tls.ConnectionState for TLS connections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -235,6 +235,16 @@ func (me *Connection) LocalAddr() net.Addr {
 	return &net.TCPAddr{}
 }
 
+// TLSConnectionState returns basic TLS details of the underlying transport.
+func (me *Connection) TLSConnectionState() tls.ConnectionState {
+	if c, ok := me.conn.(interface {
+		ConnectionState() tls.ConnectionState
+	}); ok {
+		return c.ConnectionState()
+	}
+	return tls.ConnectionState{}
+}
+
 /*
 NotifyClose registers a listener for close events either initiated by an error
 accompaning a connection.close method or by a normal shutdown.

--- a/tls_test.go
+++ b/tls_test.go
@@ -83,7 +83,7 @@ func TestTLSHandshake(t *testing.T) {
 	cert, _ := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
 	cfg.Certificates = append(cfg.Certificates, cert)
 
-	_, err := amqp.DialTLS(srv.URL, cfg)
+	c, err := amqp.DialTLS(srv.URL, cfg)
 
 	select {
 	case <-time.After(10 * time.Millisecond):
@@ -92,6 +92,11 @@ func TestTLSHandshake(t *testing.T) {
 		if string(header) != "AMQP" {
 			t.Fatalf("expected to handshake a TLS connection, got err: %v", err)
 		}
+	}
+
+	st := c.TLSConnectionState()
+	if !st.HandshakeComplete {
+		t.Errorf("TLS handshake failed, TLS connection state: %+v", st)
 	}
 }
 


### PR DESCRIPTION
I wanted to check the TLS version and cipher suite negotiated by Go and RabbitMQ.
