### PR TITLE
When confirming, return the delivery tag from Publish.

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1295,9 +1295,9 @@ When Publish does not return an error and the channel is in confirm mode, the
 internal counter for DeliveryTags with the first confirmation starting at 1.
 
 */
-func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg Publishing) error {
+func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg Publishing) (uint64, error) {
 	if err := msg.Headers.Validate(); err != nil {
-		return err
+		return 0, err
 	}
 
 	me.m.Lock()
@@ -1325,14 +1325,14 @@ func (me *Channel) Publish(exchange, key string, mandatory, immediate bool, msg 
 			AppId:           msg.AppId,
 		},
 	}); err != nil {
-		return err
+		return 0, err
 	}
 
 	if me.confirming {
-		me.confirms.Publish()
+		return me.confirms.Publish(), nil
 	}
 
-	return nil
+	return 0, nil
 }
 
 /*


### PR DESCRIPTION
With multiple goroutines publishing messages simultaneously, being able to identify which Publish resulted in which delivery tag is important for processing notifications later. If there's another way to do this, I wasn't able to find it.
