### PR TITLE
Fix data race when closing amqp connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -340,6 +340,10 @@ func (me *Connection) send(f frame) error {
 
 func (me *Connection) shutdown(err *Error) {
 	me.destructor.Do(func() {
+		me.m.Lock()
+		me.noNotify = true
+		me.m.Unlock()
+
 		if err != nil {
 			for _, c := range me.closes {
 				c <- err
@@ -363,10 +367,6 @@ func (me *Connection) shutdown(err *Error) {
 		for _, c := range me.blocks {
 			close(c)
 		}
-
-		me.m.Lock()
-		me.noNotify = true
-		me.m.Unlock()
 	})
 }
 


### PR DESCRIPTION
When using conn.NotifyClose, this later append to a list of channels
``me.closes``, while conn.shutdown() range over this list, so when a
connection is closed, ``conn.NotifyClose()`` may detect the connection closing
in the same time as the ``conn.shutdown()`` call, this is done in two
goroutine, which end up in data race where one appending to me.closes
and the other looping over it.

The fix is to move setting ``noNotify`` to True to the top of
``conn.shutdown()``, this way ``conn.NotifyClose()`` will not append to the
list anymore.