### PR TITLE
Add constants for common amqp exchange types

### DIFF
--- a/types.go
+++ b/types.go
@@ -11,6 +11,14 @@ import (
 	"time"
 )
 
+// Constants for common AMQP exchange types.
+const (
+	ExchangeDirect  = "direct"
+	ExchangeFanout  = "fanout"
+	ExchangeTopic   = "topic"
+	ExchangeHeaders = "headers"
+)
+
 var (
 	// Errors that this library could return/emit from a channel or connection
 	ErrClosed          = &Error{Code: ChannelError, Reason: "channel/connection is not open"}


### PR DESCRIPTION
It would be useful for library users to deal with constant values instead of raw strings
when choosing the exchange type. It can help to avoid mistakes which are very simple to do with plain string.

For example `net/http` package from the standard library uses the same approach for HTTP statuses and methods and it is pretty useful: https://golang.org/pkg/net/http/#pkg-constants.
