### PR TITLE
the +build tag isn't a doc comment

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,4 +1,5 @@
 // +build gofuzz
+
 package amqp
 
 import "bytes"


### PR DESCRIPTION
If you look at https://godoc.org/github.com/streadway/amqp you'll see '+build gofuzz'.