### PR TITLE
Fix rare deadlock on multiple concurrent conn.Close() calls.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -370,6 +370,7 @@ func (me *Connection) shutdown(err *Error) {
 		if err != nil {
 			me.errors <- err
 		}
+		close(me.errors) // Since the channel is buffered, the waiting goroutine will recieve the result.
 
 		me.conn.Close()
 

--- a/connection.go
+++ b/connection.go
@@ -619,7 +619,10 @@ func (me *Connection) call(req message, res ...message) error {
 	}
 
 	select {
-	case err := <-me.errors:
+	case err, ok := <-me.errors:
+		if !ok {
+			return ErrClosed
+		}
 		return err
 
 	case msg := <-me.rpc:

--- a/connection_test.go
+++ b/connection_test.go
@@ -34,3 +34,20 @@ func TestQueueDeclareOnAClosedConnectionFails(t *testing.T) {
 		log.Fatalf("queue.declare on a closed connection %s is expected to fail", conn)
 	}
 }
+
+func TestConcurrentClose(t *testing.T) {
+	conn, err := Dial("amqp://guest:guest@localhost:5672/")
+	if err != nil {
+		log.Fatalf("Could't connect to amqp server, err = %s", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		t.Run("ConcurrentClose", func(t *testing.T) {
+			t.Parallel()
+			err := conn.Close()
+			if err != nil && err != ErrClosed {
+				log.Fatalf("Expected nil or ErrClosed - got %s", err)
+			}
+		})
+	}
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"log"
+	"sync"
 	"testing"
 )
 
@@ -41,13 +42,16 @@ func TestConcurrentClose(t *testing.T) {
 		log.Fatalf("Could't connect to amqp server, err = %s", err)
 	}
 
+	wg := sync.WaitGroup{}
+	wg.Add(5)
 	for i := 0; i < 5; i++ {
-		t.Run("ConcurrentClose", func(t *testing.T) {
-			t.Parallel()
+		go func() {
 			err := conn.Close()
 			if err != nil && err != ErrClosed {
 				log.Fatalf("Expected nil or ErrClosed - got %#v, type is %T", err, err)
 			}
-		})
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -46,7 +46,7 @@ func TestConcurrentClose(t *testing.T) {
 			t.Parallel()
 			err := conn.Close()
 			if err != nil && err != ErrClosed {
-				log.Fatalf("Expected nil or ErrClosed - got %s", err)
+				log.Fatalf("Expected nil or ErrClosed - got %#v, type is %T", err, err)
 			}
 		})
 	}


### PR DESCRIPTION
Fix #226 