### PR TITLE
Don't get stuck on mixed sequences of multiple and single confirmations with unordered delivery tags

### DIFF
--- a/confirms.go
+++ b/confirms.go
@@ -78,6 +78,7 @@ func (c *confirms) Multiple(confirmed Confirmation) {
 	for c.expecting <= confirmed.DeliveryTag {
 		c.confirm(Confirmation{c.expecting, confirmed.Ack})
 	}
+	c.resequence()
 }
 
 // Close closes all listeners, discarding any out of sequence confirmations

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -54,7 +54,7 @@ func TestConfirmMixedResequences(t *testing.T) {
 	)
 	c.Listen(l)
 
-	for _, _ = range fixtures {
+	for _ = range fixtures {
 		c.Publish()
 	}
 

--- a/confirms_test.go
+++ b/confirms_test.go
@@ -42,6 +42,40 @@ func TestConfirmOneResequences(t *testing.T) {
 	}
 }
 
+func TestConfirmMixedResequences(t *testing.T) {
+	var (
+		fixtures = []Confirmation{
+			{1, true},
+			{2, true},
+			{3, true},
+		}
+		c = newConfirms()
+		l = make(chan Confirmation, len(fixtures))
+	)
+	c.Listen(l)
+
+	for _, _ = range fixtures {
+		c.Publish()
+	}
+
+	c.One(fixtures[0])
+	c.One(fixtures[2])
+	c.Multiple(fixtures[1])
+
+	for i, fix := range fixtures {
+		want := fix
+		var got Confirmation
+		select {
+		case got = <-l:
+		case <-time.After(1 * time.Second):
+			t.Fatalf("timeout on reading confirmations")
+		}
+		if want != got {
+			t.Fatalf("expected to confirm in sequence for %d, want: %+v, got: %+v", i, want, got)
+		}
+	}
+}
+
 func TestConfirmMultipleResequences(t *testing.T) {
 	var (
 		fixtures = []Confirmation{


### PR DESCRIPTION
Confirmations of publishings get stuck sometimes on mixed sequences of multiple and single confirmations with unordered delivery tags.

We just need to call resequense() for multiple publisher confirmations to fix the issue (the test added contains a real-life sequence of confirmations)