### PR TITLE
Only use TLS when the connection scheme is “amqps://“.

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -165,10 +165,6 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		config.Vhost = uri.Vhost
 	}
 
-	if uri.Scheme == "amqps" && config.TLSClientConfig == nil {
-		config.TLSClientConfig = new(tls.Config)
-	}
-
 	addr := net.JoinHostPort(uri.Host, strconv.FormatInt(int64(uri.Port), 10))
 
 	dialer := config.Dial
@@ -181,7 +177,11 @@ func DialConfig(url string, config Config) (*Connection, error) {
 		return nil, err
 	}
 
-	if config.TLSClientConfig != nil {
+	if uri.Scheme == "amqps" {
+		if config.TLSClientConfig == nil {
+			config.TLSClientConfig = new(tls.Config)
+		}
+
 		// If ServerName has not been specified in TLSClientConfig,
 		// set it to the URI host used for this connection.
 		if config.TLSClientConfig.ServerName == "" {

--- a/connection_test.go
+++ b/connection_test.go
@@ -8,6 +8,7 @@
 package amqp
 
 import (
+	"crypto/tls"
 	"net"
 	"sync"
 	"testing"
@@ -74,4 +75,23 @@ func TestConcurrentClose(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestPlaintextDialTLS esnures amqp:// connections succeed when using DialTLS.
+func TestPlaintextDialTLS(t *testing.T) {
+	uri, err := ParseURI(integrationURLFromEnv())
+	if err != nil {
+		t.Fatalf("parse URI error: %s", err)
+	}
+
+	// We can only test when we have a plaintext listener
+	if uri.Scheme != "amqp" {
+		t.Skip("requires server listening for plaintext connections")
+	}
+
+	conn, err := DialTLS(uri.String(), &tls.Config{MinVersion: tls.VersionTLS12})
+	if err != nil {
+		t.Fatalf("unexpected dial error, got %v", err)
+	}
+	conn.Close()
 }


### PR DESCRIPTION
Change the default dialer to only establish a TLS session if the connection scheme is `amqps`.

When running the integration tests locally I routinely get a failure for a single test:
```
=== RUN   TestExchangeDeclarePrecondition
--- FAIL: TestExchangeDeclarePrecondition (33.55s)
	integration_test.go:1759: dial integration server: Exception (501) Reason: "read tcp 127.0.0.1:51262->127.0.0.1:5672: i/o timeout"
```

However running this test in isolation (`-run TestExchangeDeclarePrecondition`) always passes - not sure what the craic is here.

Fixes #190.