### PR TITLE
Avoid leaking channel allocations in Connection.openChannel()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -605,6 +605,7 @@ func (c *Connection) openChannel() (*Channel, error) {
 	}
 
 	if err := ch.open(); err != nil {
+		c.releaseChannel(ch.id)
 		return nil, err
 	}
 	return ch, nil

--- a/connection_test.go
+++ b/connection_test.go
@@ -24,6 +24,23 @@ func TestChannelOpenOnAClosedConnectionFails(t *testing.T) {
 	}
 }
 
+// TestChannelOpenOnAClosedConnectionFails_ReleasesAllocatedChannel ensures the
+// channel allocated is released if opening the channel fails.
+func TestChannelOpenOnAClosedConnectionFails_ReleasesAllocatedChannel(t *testing.T) {
+	conn := integrationConnection(t, "releases channel allocation")
+	conn.Close()
+
+	before := len(conn.channels)
+
+	if _, err := conn.Channel(); err != ErrClosed {
+		t.Fatalf("channel.open on a closed connection %#v is expected to fail", conn)
+	}
+
+	if len(conn.channels) != before {
+		t.Fatalf("channel.open failed, but the allocated channel was not released")
+	}
+}
+
 func TestQueueDeclareOnAClosedConnectionFails(t *testing.T) {
 	conn := integrationConnection(t, "queue declare on close")
 	ch, _ := conn.Channel()


### PR DESCRIPTION
When opening a new channel (using `Connection.Channel()`), a new channel is allocated and added to the connection channel map (in `Connection.allocateChannel()`) before sending a `channel.open` frame to the server (in `Connection.openChannel()`).

If the `channel.open` frame fails, the allocated channel is not released, leading to a memory leak.

This patch ensures that the allocated channel is released if the `channel.open` frame send fails.

