### PR TITLE
Default to en_US locale

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -136,7 +136,7 @@ func (t *server) connectionStart() {
 		VersionMajor: 0,
 		VersionMinor: 9,
 		Mechanisms:   "PLAIN",
-		Locales:      "en-us",
+		Locales:      "en_US",
 	})
 
 	t.recv(0, &t.start)
@@ -188,6 +188,10 @@ func TestDefaultClientProperties(t *testing.T) {
 	}
 
 	if want, got := defaultVersion, srv.start.ClientProperties["version"]; want != got {
+		t.Errorf("expected version %s got: %s", want, got)
+	}
+
+	if want, got := defaultLocale, srv.start.Locale; want != got {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
 }
@@ -261,7 +265,7 @@ func TestOpenFailedSASLUnsupportedMechanisms(t *testing.T) {
 			VersionMajor: 0,
 			VersionMinor: 9,
 			Mechanisms:   "KERBEROS NTLM",
-			Locales:      "en-us",
+			Locales:      "en_US",
 		})
 	}()
 

--- a/client_test.go
+++ b/client_test.go
@@ -26,7 +26,11 @@ type server struct {
 }
 
 func defaultConfig() Config {
-	return Config{SASL: []Authentication{&PlainAuth{"guest", "guest"}}, Vhost: "/"}
+	return Config{
+		SASL:   []Authentication{&PlainAuth{"guest", "guest"}},
+		Vhost:  "/",
+		Locale: defaultLocale,
+	}
 }
 
 func newSession(t *testing.T) (io.ReadWriteCloser, *server) {
@@ -192,7 +196,7 @@ func TestDefaultClientProperties(t *testing.T) {
 	}
 
 	if want, got := defaultLocale, srv.start.Locale; want != got {
-		t.Errorf("expected version %s got: %s", want, got)
+		t.Errorf("expected locale %s got: %s", want, got)
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -26,6 +26,7 @@ const (
 	defaultProduct           = "https://github.com/streadway/amqp"
 	defaultVersion           = "β"
 	defaultChannelMax        = maxChannelMax
+	defaultLocale            = "en_US"
 )
 
 // Config is used in DialConfig and Open to specify the desired tuning
@@ -55,6 +56,9 @@ type Config struct {
 	// This is an optional setting - if the application does not set this,
 	// the underlying library will use a generic set of client properties.
 	Properties Table
+
+	// Locale negotiated between the client and the server
+	Locale string
 
 	// Dial returns a net.Conn prepared for a TLS handshake with TSLClientConfig,
 	// then an AMQP connection handshake.
@@ -91,9 +95,10 @@ type Connection struct {
 
 	Config Config // The negotiated Config after connection.open
 
-	Major      int   // Server's major version
-	Minor      int   // Server's minor version
-	Properties Table // Server properties
+	Major      int      // Server's major version
+	Minor      int      // Server's minor version
+	Properties Table    // Server properties
+	Locales    []string // Server locales
 
 	closed int32 // Will be 1 if the connection is closed, 0 otherwise. Should only be accessed as atomic
 }
@@ -163,6 +168,10 @@ func DialConfig(url string, config Config) (*Connection, error) {
 
 	if config.Vhost == "" {
 		config.Vhost = uri.Vhost
+	}
+
+	if config.Locale == "" {
+		config.Locale = defaultLocale
 	}
 
 	addr := net.JoinHostPort(uri.Host, strconv.FormatInt(int64(uri.Port), 10))
@@ -689,6 +698,7 @@ func (c *Connection) openStart(config Config) error {
 	c.Major = int(start.VersionMajor)
 	c.Minor = int(start.VersionMinor)
 	c.Properties = Table(start.ServerProperties)
+	c.Locales = strings.Split(start.Locales, " ")
 
 	// eventually support challenge/response here by also responding to
 	// connectionSecure.
@@ -717,9 +727,10 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	}
 
 	ok := &connectionStartOk{
+		ClientProperties: config.Properties,
 		Mechanism:        auth.Mechanism(),
 		Response:         auth.Response(),
-		ClientProperties: config.Properties,
+		Locale:           config.Locale,
 	}
 	tune := &connectionTune{}
 
@@ -728,6 +739,11 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 		// so at this point, we know it's an auth error, but the socket
 		// was closed instead.  Return a meaningful error.
 		return ErrCredentials
+	}
+
+	// If Locale was not negotiated in the initial handshake, use the default locale
+	if c.Config.Locale == "" {
+		c.Config.Locale = defaultLocale
 	}
 
 	// When the server and client both use default 0, then the max channel is

--- a/connection_test.go
+++ b/connection_test.go
@@ -14,6 +14,27 @@ import (
 	"testing"
 )
 
+func TestRequiredServerLocale(t *testing.T) {
+	conn := integrationConnection(t, "AMQP 0-9-1 required server locale")
+	requiredServerLocale := defaultLocale
+
+	for _, locale := range conn.Locales {
+		if locale == requiredServerLocale {
+			return
+		}
+	}
+
+	t.Fatalf("AMQP 0-9-1 server must support at least the %s locale, server sent the following locales: %#v", requiredServerLocale, conn.Locales)
+}
+
+func TestDefaultConnectionLocale(t *testing.T) {
+	conn := integrationConnection(t, "client default locale")
+
+	if conn.Config.Locale != defaultLocale {
+		t.Fatalf("Expected default connection locale to be %s, is was: %s", defaultLocale, conn.Config.Locale)
+	}
+}
+
 func TestChannelOpenOnAClosedConnectionFails(t *testing.T) {
 	conn := integrationConnection(t, "channel on close")
 


### PR DESCRIPTION
Default to en_US, [as per AMQP 0-9-1 spec](https://www.rabbitmq.com/amqp-0-9-1-reference.html).

Some AMQP servers, such as the one mentioned in #237, require a locale to be set. Since I am not aware of any AMQP server using this locale for anything else other than satisfying the AMQP spec, defaulting to en_US seems a sensible.