### PR TITLE
Guard against racy channel allocation and connection close

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -576,6 +576,10 @@ func (c *Connection) allocateChannel() (*Channel, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
+	if c.isClosed() {
+		return nil, ErrClosed
+	}
+
 	id, ok := c.allocator.next()
 	if !ok {
 		return nil, ErrChannelMax

--- a/connection_test.go
+++ b/connection_test.go
@@ -60,6 +60,27 @@ func TestRaceBetweenChannelAndConnectionClose(t *testing.T) {
 	}
 }
 
+// TestRaceBetweenChannelShutdownAndSend ensures closing a channel
+// (channel.shutdown) does not race with calling channel.send() from any other
+// goroutines.
+//
+// See https://github.com/streadway/amqp/pull/253#issuecomment-292464811 for
+// more details - thanks to jmalloc again.
+func TestRaceBetweenChannelShutdownAndSend(t *testing.T) {
+	conn := integrationConnection(t, "channel close/send race")
+	defer conn.Close()
+
+	ch, _ := conn.Channel()
+
+	go ch.Close()
+	for i := 0; i < 10; i++ {
+		go func() {
+			// ch.Ack calls ch.send() internally.
+			ch.Ack(42, false)
+		}()
+	}
+}
+
 func TestQueueDeclareOnAClosedConnectionFails(t *testing.T) {
 	conn := integrationConnection(t, "queue declare on close")
 	ch, _ := conn.Channel()


### PR DESCRIPTION
Proposes a solution to #251.

As the only write to `c.channels` is in `c.allocateChannel()` a simple `c.isClosed()` guard is sufficient to protect against concurrent writes - multiple readers is OK and does not require a lock.

Because `c.allocateChannel()` holds the connection mutex for the duration of the call and `c.shutdown()` acquires it after `c.closed` has been set, I don't believe there is any racy interaction using `c.closed`.

The test case is from the issue reported by @jmalloc - thanks it helped massively!

The changes to `channel.go` is a separate issue (and separate commit - I can remove it if you want) that eliminates a race between `channel.shutdown()` and `channel.call()`. It looks like the original code intended to avoid this race, but didn't get complete coverage - it became noticeable using `-race` after fixing the allocation race, so I included it in this PR.

Running `AMQP_URL="amqp://guest:guest@localhost:5672/" go test ./... -tags=integration -race` no longer produces any race warnings for me, though I still get:

```
--- FAIL: TestExchangeDeclarePrecondition (34.66s)
	integration_test.go:1759: dial integration server: Exception (501) Reason: "read tcp 127.0.0.1:58857->127.0.0.1:5672: i/o timeout"
```

I've always had this test case fail during integration tests and assume it's unrelated.