### PR TITLE
Fix send on closed channel panic

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -28,6 +28,7 @@ type Channel struct {
 	sendM      sync.Mutex // sequence channel frames
 	m          sync.Mutex // struct field mutex
 	confirmM   sync.Mutex // publisher confirms state mutex
+	notifyM    sync.RWMutex
 
 	connection *Connection
 
@@ -95,6 +96,10 @@ func (ch *Channel) shutdown(e *Error) {
 		ch.m.Lock()
 		defer ch.m.Unlock()
 
+		// Grab an exclusive lock for the notify channels
+		ch.notifyM.Lock()
+		defer ch.notifyM.Unlock()
+
 		// Broadcast abnormal shutdown
 		if e != nil {
 			for _, c := range ch.closes {
@@ -126,6 +131,13 @@ func (ch *Channel) shutdown(e *Error) {
 		for _, c := range ch.cancels {
 			close(c)
 		}
+
+		// Set the slices to nil to prevent the dispatch() range from sending on
+		// the now closed channels after we release the notifyM mutex
+		ch.flows = nil
+		ch.closes = nil
+		ch.returns = nil
+		ch.cancels = nil
 
 		if ch.confirms != nil {
 			ch.confirms.Close()
@@ -255,22 +267,28 @@ func (ch *Channel) dispatch(msg message) {
 		ch.send(ch, &channelCloseOk{})
 
 	case *channelFlow:
+		ch.notifyM.RLock()
 		for _, c := range ch.flows {
 			c <- m.Active
 		}
+		ch.notifyM.RUnlock()
 		ch.send(ch, &channelFlowOk{Active: m.Active})
 
 	case *basicCancel:
+		ch.notifyM.RLock()
 		for _, c := range ch.cancels {
 			c <- m.ConsumerTag
 		}
+		ch.notifyM.RUnlock()
 		ch.consumers.close(m.ConsumerTag)
 
 	case *basicReturn:
 		ret := newReturn(*m)
+		ch.notifyM.RLock()
 		for _, c := range ch.returns {
 			c <- *ret
 		}
+		ch.notifyM.RUnlock()
 
 	case *basicAck:
 		if ch.confirming {
@@ -408,8 +426,8 @@ graceful close, no error will be sent.
 
 */
 func (ch *Channel) NotifyClose(c chan *Error) chan *Error {
-	ch.m.Lock()
-	defer ch.m.Unlock()
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
 
 	if ch.noNotify {
 		close(c)
@@ -454,8 +472,8 @@ basic.ack messages from getting rate limited with your basic.publish messages.
 
 */
 func (ch *Channel) NotifyFlow(c chan bool) chan bool {
-	ch.m.Lock()
-	defer ch.m.Unlock()
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
 
 	if ch.noNotify {
 		close(c)
@@ -476,8 +494,8 @@ information about why the publishing failed.
 
 */
 func (ch *Channel) NotifyReturn(c chan Return) chan Return {
-	ch.m.Lock()
-	defer ch.m.Unlock()
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
 
 	if ch.noNotify {
 		close(c)
@@ -497,8 +515,8 @@ The subscription tag is returned to the listener.
 
 */
 func (ch *Channel) NotifyCancel(c chan string) chan string {
-	ch.m.Lock()
-	defer ch.m.Unlock()
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
 
 	if ch.noNotify {
 		close(c)
@@ -559,8 +577,8 @@ Channel.Close() or Connection.Close().
 
 */
 func (ch *Channel) NotifyPublish(confirm chan Confirmation) chan Confirmation {
-	ch.m.Lock()
-	defer ch.m.Unlock()
+	ch.notifyM.Lock()
+	defer ch.notifyM.Unlock()
 
 	if ch.noNotify {
 		close(confirm)

--- a/client_test.go
+++ b/client_test.go
@@ -599,3 +599,24 @@ func TestPublishAndShutdownDeadlockIssue84(t *testing.T) {
 		}
 	}
 }
+
+// TestChannelReturnsCloseRace ensures that receiving a basicReturn frame and
+// sending the notification to the bound channel does not race with
+// channel.shutdown() which closes all registered notification channels - checks
+// for a "send on closed channel" panic
+func TestChannelReturnsCloseRace(t *testing.T) {
+	ch := newChannel(&Connection{}, 1)
+
+	// Register a channel to close in channel.shutdown()
+	ch.NotifyReturn(make(chan Return, 1))
+
+	// Simulate receiving a load of returns (triggering a write to the above
+	// channel) while we call shutdown concurrently
+	go func() {
+		for i := 0; i < 100; i++ {
+			ch.dispatch(&basicReturn{})
+		}
+	}()
+
+	ch.shutdown(nil)
+}


### PR DESCRIPTION
During testing we hit the following panic:

```
panic: send on closed channel 

goroutine 16132 [running]: 
globalsign/hvpki/vendor/github.com/streadway/amqp.(*Channel).dispatch(0xc421973300, 0x12cd240, 0xc422528fc0) 
        /root/go/src/globalsign/hvpki/vendor/github.com/streadway/amqp/channel.go:272 +0x278 
globalsign/hvpki/vendor/github.com/streadway/amqp.(*Channel).recvContent(0xc421973300, 0x12c8600, 0xc421cdb900, 0xc4201605b8, 0x1) 
        /root/go/src/globalsign/hvpki/vendor/github.com/streadway/amqp/channel.go:374 +0x323 
globalsign/hvpki/vendor/github.com/streadway/amqp.(*Connection).dispatchN(0xc421df3e60, 0x12c8600, 0xc421cdb900) 
        /root/go/src/globalsign/hvpki/vendor/github.com/streadway/amqp/connection.go:457 +0xd0 
globalsign/hvpki/vendor/github.com/streadway/amqp.(*Connection).demux(0xc421df3e60, 0x12c8600, 0xc421cdb900) 
        /root/go/src/globalsign/hvpki/vendor/github.com/streadway/amqp/connection.go:416 +0x89 
globalsign/hvpki/vendor/github.com/streadway/amqp.(*Connection).reader(0xc421df3e60, 0x8014560e0, 0xc420370448) 
        /root/go/src/globalsign/hvpki/vendor/github.com/streadway/amqp/connection.go:508 +0x117 
created by globalsign/hvpki/vendor/github.com/streadway/amqp.Open 
        /root/go/src/globalsign/hvpki/vendor/github.com/streadway/amqp/connection.go:219 +0x32d
```

Our code has a single channel registered with `channel.NotifyReturn()`, and `channel.go:272` is attempting to send to this channel which has been concurrently closed by `channel.shutdown()`.

The original code locks the channel mutex (`ch.m`) during calls that add to the channel notify slices (`ch.flows, ch.closes, ch.returns, ch.cancels`), and also locks the mutex during calls to `channel.shutdown()` which closes the channels. However it's possible to race with receiving a frame (such as `basicReturn`) which triggers `channel.dispatch()` (which does not acquire the channel lock) into attempting to send on the now closed channel.

This PR proposes acquiring a lock in `channel.dispatch()` when dealing with `channelFlow/basicCancel/basicReturn` frames. While it's possible to use the channel mutex (`ch.m`) for this, I've opted to use a `RWMutex` that protects only the channel slices to reduce contention.