### PR TITLE
Avoid mutating the channel map while ranging over it in Connection.Shutdown()

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestRequiredServerLocale(t *testing.T) {
@@ -68,6 +69,8 @@ func TestChannelOpenOnAClosedConnectionFails_ReleasesAllocatedChannel(t *testing
 // See https://github.com/streadway/amqp/issues/251 - thanks to jmalloc for the
 // test case.
 func TestRaceBetweenChannelAndConnectionClose(t *testing.T) {
+	defer time.AfterFunc(10*time.Second, func() { panic("Close deadlock") }).Stop()
+
 	conn := integrationConnection(t, "allocation/shutdown race")
 
 	go conn.Close()
@@ -88,6 +91,8 @@ func TestRaceBetweenChannelAndConnectionClose(t *testing.T) {
 // See https://github.com/streadway/amqp/pull/253#issuecomment-292464811 for
 // more details - thanks to jmalloc again.
 func TestRaceBetweenChannelShutdownAndSend(t *testing.T) {
+	defer time.AfterFunc(10*time.Second, func() { panic("Close deadlock") }).Stop()
+
 	conn := integrationConnection(t, "channel close/send race")
 	defer conn.Close()
 


### PR DESCRIPTION
Fixes a rare race reported by @gerhard (see https://github.com/streadway/amqp/pull/253#issuecomment-297999049):

```
AMQP_URL="amqp://guest:guest@localhost:5672/" go test ./... -tags=integration -race -run=TestRaceBetweenChannelShutdownAndSend -count=10000
==================
WARNING: DATA RACE
Write at 0x00c420354f90 by goroutine 138:
  runtime.mapdelete()
      /usr/local/Cellar/go/1.8.1/libexec/src/runtime/hashmap.go:598 +0x0
  github.com/domodwyer/amqp.(*Connection).releaseChannel()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:600 +0xbc
  github.com/domodwyer/amqp.(*Connection).closeChannel()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:623 +0x70
  github.com/domodwyer/amqp.(*Channel).Close()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/channel.go:403 +0x19f

Previous read at 0x00c420354f90 by goroutine 159:
  runtime.mapiterinit()
      /usr/local/Cellar/go/1.8.1/libexec/src/runtime/hashmap.go:668 +0x0
  github.com/domodwyer/amqp.(*Connection).shutdown.func1()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:384 +0x23d
  sync.(*Once).Do()
      /usr/local/Cellar/go/1.8.1/libexec/src/sync/once.go:44 +0xe1
  github.com/domodwyer/amqp.(*Connection).shutdown()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:407 +0xcc
  github.com/domodwyer/amqp.(*Connection).dispatch0()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:431 +0x62c
  github.com/domodwyer/amqp.(*Connection).demux()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:414 +0x6e
  github.com/domodwyer/amqp.(*Connection).reader()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:508 +0x273

Goroutine 138 (running) created at:
  github.com/domodwyer/amqp.TestRaceBetweenChannelShutdownAndSend()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection_test.go:75 +0xb5
  testing.tRunner()
      /usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:657 +0x107

Goroutine 159 (running) created at:
  github.com/domodwyer/amqp.Open()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:219 +0x578
  github.com/domodwyer/amqp.DialConfig()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:200 +0x414
  github.com/domodwyer/amqp.Dial()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection.go:132 +0x88
  github.com/domodwyer/amqp.integrationConnection()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/integration_test.go:1757 +0x50
  github.com/domodwyer/amqp.TestRaceBetweenChannelShutdownAndSend()
      /Users/gerhard/go/src/github.com/domodwyer/amqp/connection_test.go:70 +0x51
  testing.tRunner()
      /usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:657 +0x107
==================
--- FAIL: TestRaceBetweenChannelShutdownAndSend (0.01s)
	shared_test.go:68: channel close/send race close
	testing.go:610: race detected during execution of test
FAIL
FAIL	github.com/domodwyer/amqp	89.099s
```

Even though we copy the slice of `c.closes`, the underlying elements in the array are pointers (see https://golang.org/src/runtime/chan.go#L62) so ranging over the copied slice has no effect.

This PR holds the connection mutex `c.m` for nearly the entire `Channel.shutdown()` call, ranging over the `c.closes` directly.

Instead of calling `channel.closeChannel()` which requires a lock further down the call chain, we directly call `channel.shutdown()` and release the channel map and allocator directly.

We could possibly set `c.channels` and `c.allocator` to `nil` and avoid the GC collection, but it seems riskier - we could hit a nil panic via some other code path, I've not investigated this option though I'm open to ideas!

When running integration tests, I see no deadlocks or races.