### PR TITLE
Protect allocator

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -814,7 +814,9 @@ func (c *Connection) openComplete() error {
 		_ = deadliner.SetDeadline(time.Time{})
 	}
 
+	c.m.Lock()
 	c.allocator = newAllocator(1, c.Config.ChannelMax)
+	c.m.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Race condition with `connection.go:418`.