### PR TITLE
Fixes #274: when connection fails, library closes the "confirm" chann…

### DIFF
--- a/_examples/pubsub/pubsub.go
+++ b/_examples/pubsub/pubsub.go
@@ -87,14 +87,14 @@ func redial(ctx context.Context, url string) chan chan session {
 // publish publishes messages to a reconnecting session to a fanout exchange.
 // It receives from the application specific source of messages.
 func publish(sessions chan chan session, messages <-chan message) {
-	var (
-		running bool
-		reading = messages
-		pending = make(chan message, 1)
-		confirm = make(chan amqp.Confirmation, 1)
-	)
-
 	for session := range sessions {
+		var (
+			running bool
+			reading = messages
+			pending = make(chan message, 1)
+			confirm = make(chan amqp.Confirmation, 1)
+		)
+
 		pub := <-session
 
 		// publisher confirms for this channel/connection


### PR DESCRIPTION
…el, and the new connection is trying writing to the closed confirm channel which causes panic. Recreating channels for each connection fixes the issue.