### PR TITLE
Fix release channel id before send channelCloseOk cause CHANNEL_ERROR

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -276,6 +276,7 @@ func (ch *Channel) dispatch(msg message) {
 	case *channelClose:
 		ch.connection.closeChannel(ch, newError(m.ReplyCode, m.ReplyText))
 		ch.send(&channelCloseOk{})
+		ch.connection.releaseChannel(ch.id)
 
 	case *channelFlow:
 		ch.notifyM.RLock()
@@ -418,6 +419,7 @@ It is safe to call this method multiple times.
 
 */
 func (ch *Channel) Close() error {
+	defer ch.connection.releaseChannel(ch.id)
 	defer ch.connection.closeChannel(ch, nil)
 	return ch.call(
 		&channelClose{ReplyCode: replySuccess},

--- a/connection.go
+++ b/connection.go
@@ -633,7 +633,6 @@ func (c *Connection) openChannel() (*Channel, error) {
 // this connection.
 func (c *Connection) closeChannel(ch *Channel, e *Error) {
 	ch.shutdown(e)
-	c.releaseChannel(ch.id)
 }
 
 /*


### PR DESCRIPTION
When Server sends a ChannelClose with some exception(like ACCESS_REFUSED), and the user opens a new channel on the same connection immediately. The new channel will use the old one's channel id, and it will cause a new exception `Exception (504) Reason: "CHANNEL_ERROR - second 'channel.open' seen"` which closed the connection.

<img width="596" alt="2017-07-06 22 24 46" src="https://user-images.githubusercontent.com/4199641/27915852-00dc9fc0-629a-11e7-959b-30a6f9c3ed9e.png">
