### PR TITLE
Fix publish channel redial

### DIFF
--- a/_examples/pubsub/pubsub.go
+++ b/_examples/pubsub/pubsub.go
@@ -111,7 +111,10 @@ func publish(sessions chan chan session, messages <-chan message) {
 		for {
 			var body message
 			select {
-			case confirmed := <-confirm:
+			case confirmed, ok := <-confirm:
+				if !ok {
+					break Publish
+				}
 				if !confirmed.Ack {
 					log.Printf("nack message %d, body: %q", confirmed.DeliveryTag, string(body))
 				}


### PR DESCRIPTION
When publish connection is closed, it goes to infinite loop. We need to watch the "confirmed" channel to be closed and break the loop to redial.