### PR TITLE
Clarify RabbitMQ implementation of the global flag for Qos

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -624,7 +624,11 @@ started with noAck.
 When global is true, these Qos settings apply to all existing and future
 consumers on all channels on the same connection.  When false, the Channel.Qos
 settings will apply to all existing and future consumers on this channel.
-RabbitMQ does not implement the global flag.
+
+Please see the RabbitMQ Consumer Prefetch documentation for an explanation of
+how the global flag is implemented in RabbitMQ, as it is differs from the
+AMQP 0.9.1 specification in that global Qos settings are limited in scope to
+channels, not connections (https://www.rabbitmq.com/consumer-prefetch.html).
 
 To get round-robin behavior between consumers consuming from the same queue on
 different connections, set the prefetch count to 1, and the next available

--- a/channel.go
+++ b/channel.go
@@ -626,7 +626,7 @@ consumers on all channels on the same connection.  When false, the Channel.Qos
 settings will apply to all existing and future consumers on this channel.
 
 Please see the RabbitMQ Consumer Prefetch documentation for an explanation of
-how the global flag is implemented in RabbitMQ, as it is differs from the
+how the global flag is implemented in RabbitMQ, as it differs from the
 AMQP 0.9.1 specification in that global Qos settings are limited in scope to
 channels, not connections (https://www.rabbitmq.com/consumer-prefetch.html).
 


### PR DESCRIPTION
Includes a link to the RabbitMQ documentation

Fixes #310