### PR TITLE
Open Vhost failed should return the real error which send from server.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -326,8 +326,8 @@ func TestOpenFailedVhost(t *testing.T) {
 	}()
 
 	c, err := Open(rwc, defaultConfig())
-	if err != ErrVhost {
-		t.Fatalf("expected ErrVhost got: %+v on %+v", err, c)
+	if err == nil {
+		t.Fatalf("expected not nil error got: %+v on %+v", err, c)
 	}
 }
 

--- a/connection.go
+++ b/connection.go
@@ -794,7 +794,7 @@ func (c *Connection) openVhost(config Config) error {
 
 	if err := c.call(req, res); err != nil {
 		// Cannot be closed yet, but we know it's a vhost problem
-		return ErrVhost
+		return err
 	}
 
 	c.Config.Vhost = config.Vhost


### PR DESCRIPTION
In the latest version of RabbitMQ,  I set the `max-connections` limitation for a vhost. When I opening
several connections that try to connection to RabbitMQ.  The client shows an `ErrVhost` error. However, we expect to receive a similar error where send from server like this: 
```bash
Exception (530) Reason: "NOT_ALLOWED - access to vhost 'test_vhost' refused for user 'guest': connection limit (2) is reached"
```
Therefore, I think it is reasonable to return the original error where send from server.