### PR TITLE
#306 Always generate a correct consumer tag

### DIFF
--- a/consumers.go
+++ b/consumers.go
@@ -6,16 +6,30 @@
 package amqp
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 )
 
 var consumerSeq uint64
 
+const consumerTagLengthMax = 0xFF // see writeShortstr
+
 func uniqueConsumerTag() string {
-	return fmt.Sprintf("ctag-%s-%d", os.Args[0], atomic.AddUint64(&consumerSeq, 1))
+	return commandNameBasedUniqueConsumerTag(os.Args[0])
+}
+
+func commandNameBasedUniqueConsumerTag(commandName string) string {
+	tagPrefix := "ctag-"
+	tagInfix := commandName
+	tagSuffix := "-" + strconv.FormatUint(atomic.AddUint64(&consumerSeq, 1), 10)
+
+	if len(tagPrefix)+len(tagInfix)+len(tagSuffix) > consumerTagLengthMax {
+		tagInfix = "streadway/amqp"
+	}
+
+	return tagPrefix + tagInfix + tagSuffix
 }
 
 type consumerBuffers map[string]chan *Delivery

--- a/consumers_test.go
+++ b/consumers_test.go
@@ -1,0 +1,20 @@
+package amqp
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGeneratedUniqueConsumerTagDoesNotExceedMaxLength(t *testing.T) {
+	assertCorrectLength := func(commandName string) {
+		tag := commandNameBasedUniqueConsumerTag(commandName)
+		if len(tag) > consumerTagLengthMax {
+			t.Error("Generated unique consumer tag exceeds maximum length:", tag)
+		}
+	}
+
+	assertCorrectLength("test")
+	assertCorrectLength(strings.Repeat("z", 249))
+	assertCorrectLength(strings.Repeat("z", 256))
+	assertCorrectLength(strings.Repeat("z", 1024))
+}


### PR DESCRIPTION
Consumer tags exceeding maximum length have resulted in failures to map
basicConsume messages back to consumers, ultimately dropping deliveries
without sending ack or nack.

A proper fix is to add validation for all strings in configuration and
fail early if any of the configured parameters exceeds limits set by
the protocol.