### PR TITLE
Add option to force disable heartbeats

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -46,6 +46,9 @@ type Config struct {
 	FrameSize  int           // 0 max bytes means unlimited
 	Heartbeat  time.Duration // less than 1s uses the server's interval
 
+	// Force heartbeats to be disabled, even if server specifies an interval
+	DisableHeartbeat bool
+
 	// TLSClientConfig specifies the client configuration of the TLS connection
 	// when establishing a tls transport.
 	// If the URL uses an amqps scheme, then an empty tls.Config with the
@@ -769,6 +772,9 @@ func (c *Connection) openTune(config Config, auth Authentication) error {
 	c.Config.Heartbeat = time.Second * time.Duration(pick(
 		int(config.Heartbeat/time.Second),
 		int(tune.Heartbeat)))
+	if config.DisableHeartbeat {
+		c.Config.Heartbeat = 0
+	}
 
 	// "The client should start sending heartbeats after receiving a
 	// Connection.Tune method"


### PR DESCRIPTION
This adds a `DisableHeartbeat bool` option in `Config` that overrides the `pick` behavior to set the heartbeat interval to 0, even if the server proposes one.

Justification: Our client is running in an AWS Lambda, which can have its execution context "frozen" when the Lambda is idle. This means that if the Lambda is invoked intermittently, there's no guarantee that heartbeats will fire in time. We're also using CloudAMQP, which doesn't provide any control over its server-proposed heartbeat intervals.

As a side note, CloudAMQP recommends disabling heartbeats when using their service, since they implement TCP keep-alive: https://www.cloudamqp.com/docs/celery.html (See the note under "broker_heartbeat")