### PR TITLE
Channel exposes confirms in order to get sequential number of the published messages

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -1585,3 +1585,8 @@ func (ch *Channel) Reject(tag uint64, requeue bool) error {
 		Requeue:     requeue,
 	})
 }
+
+// Confirms returns control structure over confirm mode
+func (ch *Channel) Confirms() *confirms {
+	return ch.confirms
+}

--- a/confirms.go
+++ b/confirms.go
@@ -20,6 +20,14 @@ func newConfirms() *confirms {
 	}
 }
 
+// Published returns sequential number of published messages
+func (c *confirms) Published() uint64 {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	return c.published
+}
+
 func (c *confirms) Listen(l chan Confirmation) {
 	c.m.Lock()
 	defer c.m.Unlock()


### PR DESCRIPTION
Hello guys.

It looks like the current implementation doesn't allow the client to get DeliveryTag in the moment of publishing. It makes life a bit harder, and the user should implement his way of tracking published messages. Would it be better to expose counter which already in place?

Related to #63 question

Thank you