### PR TITLE
Use atomic data type to count published messages

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1195,8 +1195,11 @@ func TestIntegrationConfirmNoLocks(t *testing.T) {
 
 		var wg sync.WaitGroup
 
+		finished := false
 		time.AfterFunc(time.Second*10, func() {
-			panic("deadlock")
+			if !finished {
+				panic("deadlock")
+			}
 		})
 
 		messagesNumber := 10000
@@ -1211,6 +1214,8 @@ func TestIntegrationConfirmNoLocks(t *testing.T) {
 
 		}()
 		wg.Wait()
+
+		finished = true
 	}
 }
 


### PR DESCRIPTION
When running publisher in confirm mode I kept running into deadlocks. After some digging I have figured out that mutex on publish is the culprit. Atomic value fixes the issue by removing mutex from the function.

Issue: https://github.com/streadway/amqp/issues/333