### PR TITLE
QueueBind documentation fix

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -889,7 +889,7 @@ and exchanges will also be restored on server restart.
 If the binding could not complete, an error will be returned and the channel
 will be closed.
 
-When noWait is true and the queue could not be bound, the channel will be
+When noWait is false and the queue could not be bound, the channel will be
 closed with an error.
 
 */


### PR DESCRIPTION
Small documentation error - when noWait is true, it is assumed that queue exists, so it wouldn't close channel with an error.