### PR TITLE
`ex[]hange` -> `ex[c]hange`

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -52,7 +52,7 @@ type Delivery struct {
 
 	DeliveryTag uint64
 	Redelivered bool
-	Exchange    string // basic.publish exhange
+	Exchange    string // basic.publish exchange
 	RoutingKey  string // basic.publish routing key
 
 	Body []byte


### PR DESCRIPTION
This is a comment spelling fix which affects the API documentation.