### PR TITLE
Make IsClosed() for Connection public. Closes #376

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -317,7 +317,7 @@ including the underlying io, Channels, Notify listeners and Channel consumers
 will also be closed.
 */
 func (c *Connection) Close() error {
-	if c.isClosed() {
+	if c.IsClosed() {
 		return ErrClosed
 	}
 
@@ -332,7 +332,7 @@ func (c *Connection) Close() error {
 }
 
 func (c *Connection) closeWith(err *Error) error {
-	if c.isClosed() {
+	if c.IsClosed() {
 		return ErrClosed
 	}
 
@@ -346,12 +346,14 @@ func (c *Connection) closeWith(err *Error) error {
 	)
 }
 
-func (c *Connection) isClosed() bool {
+// IsClosed returns true if the connection is marked as closed, otherwise false
+// is returned.
+func (c *Connection) IsClosed() bool {
 	return (atomic.LoadInt32(&c.closed) == 1)
 }
 
 func (c *Connection) send(f frame) error {
-	if c.isClosed() {
+	if c.IsClosed() {
 		return ErrClosed
 	}
 
@@ -591,7 +593,7 @@ func (c *Connection) allocateChannel() (*Channel, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	if c.isClosed() {
+	if c.IsClosed() {
 		return nil, ErrClosed
 	}
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -178,3 +178,18 @@ func TestPlaintextDialTLS(t *testing.T) {
 	}
 	conn.Close()
 }
+
+// TestIsClosed will test the public method IsClosed on a connection.
+func TestIsClosed(t *testing.T) {
+	conn := integrationConnection(t, "public IsClosed()")
+
+	if conn.IsClosed() {
+		t.Fatalf("connection expected to not be marked as closed")
+	}
+
+	conn.Close()
+
+	if !conn.IsClosed() {
+		t.Fatal("connection expected to be marked as closed")
+	}
+}


### PR DESCRIPTION
PR in reference to #376 and [Google Groups](https://groups.google.com/forum/#!topic/rabbitmq-users/x6oGr07nm8k) discussion to change `isClosed` to public `IsClosed`. 

Test result with `-cpu 2 -tags integration -race`:
```
PASS
ok      github.com/streadway/amqp       147.177s
```