### PR TITLE
print validate not support type

### DIFF
--- a/types.go
+++ b/types.go
@@ -246,7 +246,7 @@ func validateField(f interface{}) error {
 		return nil
 	}
 
-	return fmt.Errorf("value %t not supported", f)
+	return fmt.Errorf("value %T not supported", f)
 }
 
 // Validate returns and error if any Go types in the table are incompatible with AMQP types.


### PR DESCRIPTION
if argument of validateField function is not supported  type, such as `uint32`,
 I got: `table field "x-message-ttl" value %!t(uint32=300000) not supported`,
 now I fix it and print actually type: ` table field "x-message-ttl" value uint32 not supported`.
