### PR TITLE
travis-ci: Install rabbitmq-server package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: go
 
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
+
 go:
   - 1.10.x
   - 1.11.x


### PR DESCRIPTION
Travis standard build images no longer include the RabbitMQ by default. The `addons` section adds the required apt packages.

Without this we can see Travis build failures (can't dial to 127.0.0.1:5672).