### PR TITLE
Channel buffer size is accessed through `cap` not `len`

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -553,7 +553,7 @@ ordered Ack and Nack DeliveryTag to the respective channels.
 For strict ordering, use NotifyPublish instead.
 */
 func (ch *Channel) NotifyConfirm(ack, nack chan uint64) (chan uint64, chan uint64) {
-	confirms := ch.NotifyPublish(make(chan Confirmation, len(ack)+len(nack)))
+	confirms := ch.NotifyPublish(make(chan Confirmation, cap(ack)+cap(nack)))
 
 	go func() {
 		for c := range confirms {


### PR DESCRIPTION
It’s really confusing that for channels, it is `make(chan T, capacity)`. So that `len(chan T)` gives how many items are in the buffer, while `cap(chan T)` gives the buffer size.

As a result, we almost certainly do not have anything queued onto the `ack` and `nack` channels already, which means these `len(…)` calls are almost certainly always zero.