### PR TITLE
cap of channel, not len, which is the number of items on the channel

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -553,7 +553,7 @@ ordered Ack and Nack DeliveryTag to the respective channels.
 For strict ordering, use NotifyPublish instead.
 */
 func (ch *Channel) NotifyConfirm(ack, nack chan uint64) (chan uint64, chan uint64) {
-	confirms := ch.NotifyPublish(make(chan Confirmation, len(ack)+len(nack)))
+	confirms := ch.NotifyPublish(make(chan Confirmation, cap(ack)+cap(nack)))
 
 	go func() {
 		for c := range confirms {


### PR DESCRIPTION
Cherry-pick of 8b6533e8ccbbc8c7c1cb7861a7e505ce7921677f #426 