### PR TITLE
c.reader() not always exit on c.Close()

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -528,7 +528,12 @@ func (c *Connection) reader(r io.Reader) {
 		c.demux(frame)
 
 		if haveDeadliner {
-			c.deadlines <- conn
+			select {
+			case c.deadlines <- conn:
+			default:
+				// On c.Close() c.heartbeater() might exit just before c.deadlines <- conn is called.
+				// Which result in this goroutine being stuck forever.
+			}
 		}
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -532,7 +532,7 @@ func (c *Connection) reader(r io.Reader) {
 			case c.deadlines <- conn:
 			default:
 				// On c.Close() c.heartbeater() might exit just before c.deadlines <- conn is called.
-				// Which result in this goroutine being stuck forever.
+				// Which results in this goroutine being stuck forever.
 			}
 		}
 	}


### PR DESCRIPTION
On c.Close() c.heartbeater() might exit just before c.deadlines <- conn is called. Which results in this goroutine being stuck forever.