### PR TITLE
Increase publish performance of small message ~500%

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -189,6 +189,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 	if err != nil {
 		return nil, err
 	}
+	conn.(*net.TCPConn).SetNoDelay(false)
 
 	if uri.Scheme == "amqps" {
 		if config.TLSClientConfig == nil {

--- a/write.go
+++ b/write.go
@@ -27,6 +27,20 @@ func (w *writer) WriteFrame(frame frame) (err error) {
 	return
 }
 
+func (w *writer) WriteFrames(frames [3]frame) (err error) {
+	for _, frame := range frames {
+		if err = frame.write(w.w); err != nil {
+			return
+		}
+	}
+
+	if buf, ok := w.w.(*bufio.Writer); ok {
+		err = buf.Flush()
+	}
+
+	return
+}
+
 func (f *methodFrame) write(w io.Writer) (err error) {
 	var payload bytes.Buffer
 


### PR DESCRIPTION
By writing all 3 frames required for a publish in one go, and only
locking and flushing the output buffer once we increase the performance
about 3 times.

Messages that spans over multiple body frames are still written one at a
time, when messages are that large (>128KB) the locking and flushing is
not the bottleneck, and it allows us to not allocate a dynamic array for
each publish and allows us to use a fixed size array instead.

By disabling TCP no delay (enable Nagle's algorithm) many small messages
can be sent in a single TCP packet, we increase the publish rate about
100% when messages are small.

This will not increase latency in any normal circumstances, but
theoretically could if for instance one channel is publishing a message,
and another channel is declaring a queue and then waiting for the CreateOK
response, then due to a delayed ack from the server a 40ms delay could
be added to the wait of the Queue CreateOK.



