### PR TITLE
export default dial settings

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -29,7 +29,7 @@ func defaultConfig() Config {
 	return Config{
 		SASL:   []Authentication{&PlainAuth{"guest", "guest"}},
 		Vhost:  "/",
-		Locale: defaultLocale,
+		Locale: DefaultLocale,
 	}
 }
 
@@ -214,7 +214,7 @@ func TestDefaultClientProperties(t *testing.T) {
 		t.Errorf("expected version %s got: %s", want, got)
 	}
 
-	if want, got := defaultLocale, srv.start.Locale; want != got {
+	if want, got := DefaultLocale, srv.start.Locale; want != got {
 		t.Errorf("expected locale %s got: %s", want, got)
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -21,14 +21,14 @@ import (
 const (
 	maxChannelMax = (2 << 15) - 1
 
-	defaultHeartbeat         = 10 * time.Second
-	defaultConnectionTimeout = 30 * time.Second
+	DefaultHeartbeat         = 10 * time.Second
+	DefaultConnectionTimeout = 30 * time.Second
 	defaultProduct           = "https://github.com/streadway/amqp"
 	defaultVersion           = "β"
 	// Safer default that makes channel leaks a lot easier to spot
 	// before they create operational headaches. See https://github.com/rabbitmq/rabbitmq-server/issues/1593.
 	defaultChannelMax = (2 << 10) - 1
-	defaultLocale     = "en_US"
+	DefaultLocale     = "en_US"
 )
 
 // Config is used in DialConfig and Open to specify the desired tuning
@@ -139,8 +139,8 @@ func DefaultDial(connectionTimeout time.Duration) func(network, addr string) (ne
 // scheme.  It is equivalent to calling DialTLS(amqp, nil).
 func Dial(url string) (*Connection, error) {
 	return DialConfig(url, Config{
-		Heartbeat: defaultHeartbeat,
-		Locale:    defaultLocale,
+		Heartbeat: DefaultHeartbeat,
+		Locale:    DefaultLocale,
 	})
 }
 
@@ -151,9 +151,9 @@ func Dial(url string) (*Connection, error) {
 // DialTLS uses the provided tls.Config when encountering an amqps:// scheme.
 func DialTLS(url string, amqps *tls.Config) (*Connection, error) {
 	return DialConfig(url, Config{
-		Heartbeat:       defaultHeartbeat,
+		Heartbeat:       DefaultHeartbeat,
 		TLSClientConfig: amqps,
-		Locale:          defaultLocale,
+		Locale:          DefaultLocale,
 	})
 }
 
@@ -182,7 +182,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 
 	dialer := config.Dial
 	if dialer == nil {
-		dialer = DefaultDial(defaultConnectionTimeout)
+		dialer = DefaultDial(DefaultConnectionTimeout)
 	}
 
 	conn, err = dialer("tcp", addr)

--- a/connection.go
+++ b/connection.go
@@ -30,7 +30,8 @@ const (
 	// Safer default that makes channel leaks a lot easier to spot
 	// before they create operational headaches. See https://github.com/rabbitmq/rabbitmq-server/issues/1593.
 	defaultChannelMax = (2 << 10) - 1
-	DefaultLocale     = "en_US"
+	// DefaultLocale is the default connection locale.
+	DefaultLocale = "en_US"
 )
 
 // Config is used in DialConfig and Open to specify the desired tuning

--- a/connection.go
+++ b/connection.go
@@ -21,7 +21,9 @@ import (
 const (
 	maxChannelMax = (2 << 15) - 1
 
-	DefaultHeartbeat         = 10 * time.Second
+	// DefaultHeartbeat is the default heartbeat interval
+	DefaultHeartbeat = 10 * time.Second
+	// DefaultConnectionTimeout is the default connection timeout
 	DefaultConnectionTimeout = 30 * time.Second
 	defaultProduct           = "https://github.com/streadway/amqp"
 	defaultVersion           = "β"

--- a/connection_test.go
+++ b/connection_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestRequiredServerLocale(t *testing.T) {
 	conn := integrationConnection(t, "AMQP 0-9-1 required server locale")
-	requiredServerLocale := defaultLocale
+	requiredServerLocale := DefaultLocale
 
 	for _, locale := range conn.Locales {
 		if locale == requiredServerLocale {
@@ -31,8 +31,8 @@ func TestRequiredServerLocale(t *testing.T) {
 func TestDefaultConnectionLocale(t *testing.T) {
 	conn := integrationConnection(t, "client default locale")
 
-	if conn.Config.Locale != defaultLocale {
-		t.Fatalf("Expected default connection locale to be %s, is was: %s", defaultLocale, conn.Config.Locale)
+	if conn.Config.Locale != DefaultLocale {
+		t.Fatalf("Expected default connection locale to be %s, is was: %s", DefaultLocale, conn.Config.Locale)
 	}
 }
 


### PR DESCRIPTION
When DialConfig() is called, no default value is set for the
Config.heartbeat and Config.Locale settings when they are 0.

Export the Dialer default values, so users can create custom DialConfigs
that use some of the default values without having to redefine and copy
them.
The DefaultConnectionTimeout is also exported to allow reusing the
default in custom dial functions