### PR TITLE
Exporting IsClosed for Channel

### DIFF
--- a/channel.go
+++ b/channel.go
@@ -433,6 +433,12 @@ func (ch *Channel) Close() error {
 	)
 }
 
+// IsClosed returns true if the channel is marked as closed, otherwise false
+// is returned.
+func (ch *Channel) IsClosed() bool {
+	return (atomic.LoadInt32(&ch.closed) == 1)
+}
+
 /*
 NotifyClose registers a listener for when the server sends a channel or
 connection exception in the form of a Connection.Close or Channel.Close method.

--- a/connection_test.go
+++ b/connection_test.go
@@ -193,3 +193,19 @@ func TestIsClosed(t *testing.T) {
 		t.Fatal("connection expected to be marked as closed")
 	}
 }
+
+// TestChannelIsClosed will test the public method IsClosed on a channel.
+func TestChannelIsClosed(t *testing.T) {
+	conn := integrationConnection(t, "public channel.IsClosed()")
+	ch, _ := conn.Channel()
+
+	if ch.IsClosed() {
+		t.Fatalf("connection expected to not be marked as closed")
+	}
+
+	ch.Close()
+
+	if !ch.IsClosed() {
+		t.Fatal("connection expected to be marked as closed")
+	}
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -200,12 +200,12 @@ func TestChannelIsClosed(t *testing.T) {
 	ch, _ := conn.Channel()
 
 	if ch.IsClosed() {
-		t.Fatalf("connection expected to not be marked as closed")
+		t.Fatalf("channel expected to not be marked as closed")
 	}
 
 	ch.Close()
 
 	if !ch.IsClosed() {
-		t.Fatal("connection expected to be marked as closed")
+		t.Fatal("channel expected to be marked as closed")
 	}
 }


### PR DESCRIPTION
I needed to access the Channel status on a project that I'm participating in. So, I just made the "closed" field public on `channel.go` in the same way as it is on `connection.go`.  Nothing too fancy, but I think it is important to get the actual status of the channel.

Something that we have on RabbitMQ's client on Python ([pika](https://github.com/pika/pika/blob/a3ae3e5aae3fd546e9ae73bff0175f5d61a9d39a/pika/adapters/blocking_connection.py#L1295)) and .Net ([RabbitMQ](https://github.com/rabbitmq/rabbitmq-dotnet-client/blob/830c7470d71efa53594c92ecbd924bef613468c8/projects/RabbitMQ.Client/client/api/IModel.cs#L87)) and I missed here.

Hope this helps,
Best regards.