### PR TITLE
Use atomic operation to prevent deadlock when publishing in confirm mode

### DIFF
--- a/confirms.go
+++ b/confirms.go
@@ -1,6 +1,9 @@
 package amqp
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // confirms resequences and notifies one or multiple publisher confirmation listeners
 type confirms struct {
@@ -29,11 +32,7 @@ func (c *confirms) Listen(l chan Confirmation) {
 
 // publish increments the publishing counter
 func (c *confirms) Publish() uint64 {
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	c.published++
-	return c.published
+	return atomic.AddUint64(&c.published, 1)
 }
 
 // confirm confirms one publishing, increments the expecting delivery tag, and


### PR DESCRIPTION
When producer push message and confirm message in one goroutine, deadlock would occur. In [confirms.go](https://github.com/streadway/amqp/blob/master/confirms.go), Publish method might wait lock infinitely that One method held once confirm channel blocked. So I'd like to use atomic operation to avoid it.