### PR TITLE
(Continued) Added support for cert-only login without user and password

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -48,21 +48,21 @@ func (auth *AMQPlainAuth) Response() string {
 	return fmt.Sprintf("LOGIN:%sPASSWORD:%s", auth.Username, auth.Password)
 }
 
-// CertAuth for RabbitMQ-auth-mechanism-ssl.
-type CertAuth struct {
+// ExternalAuth for RabbitMQ-auth-mechanism-ssl.
+type ExternalAuth struct {
 }
 
-func (me *CertAuth) Mechanism() string {
+// Mechanism returns "EXTERNAL"
+func (me *ExternalAuth) Mechanism() string {
 	return "EXTERNAL"
 }
 
-func (me *CertAuth) Response() string {
-	return fmt.Sprintf("\000*\000*")
+func (me *ExternalAuth) Response() string {
+	return "\000*\000*"
 }
 
 // Finds the first mechanism preferred by the client that the server supports.
 func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth Authentication, ok bool) {
-
 	for _, auth = range client {
 		for _, mech := range serverMechanisms {
 			if auth.Mechanism() == mech {

--- a/auth.go
+++ b/auth.go
@@ -48,8 +48,21 @@ func (auth *AMQPlainAuth) Response() string {
 	return fmt.Sprintf("LOGIN:%sPASSWORD:%s", auth.Username, auth.Password)
 }
 
+// CertAuth for RabbitMQ-auth-mechanism-ssl.
+type CertAuth struct {
+}
+
+func (me *CertAuth) Mechanism() string {
+	return "EXTERNAL"
+}
+
+func (me *CertAuth) Response() string {
+	return fmt.Sprintf("\000*\000*")
+}
+
 // Finds the first mechanism preferred by the client that the server supports.
 func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth Authentication, ok bool) {
+
 	for _, auth = range client {
 		for _, mech := range serverMechanisms {
 			if auth.Mechanism() == mech {

--- a/connection.go
+++ b/connection.go
@@ -155,6 +155,25 @@ func DialTLS(url string, amqps *tls.Config) (*Connection, error) {
 		TLSClientConfig: amqps,
 		Locale:          defaultLocale,
 	})
+
+}
+
+// DialTLS_CertAuth accepts a string in the AMQP URI format and returns a new
+// Connection over TCP using EXTERNAL auth.  Defaults to a server heartbeat
+// interval of 10 seconds and sets the initial read deadline to 30 seconds.
+//
+// This mechanism is used, when RabbitMQ is configured for EXTERNAL auth with
+// ssl_cert_login plugin for userless/passwordless logons
+//
+// DialTLS_CertAuth uses the provided tls.Config when encountering an amqps://
+// scheme.
+func DialTLS_CertAuth(url string, amqps *tls.Config) (*Connection, error) {
+
+	return DialConfig(url, Config{
+		Heartbeat:       defaultHeartbeat,
+		TLSClientConfig: amqps,
+		SASL:            []Authentication{&CertAuth{}},
+	})
 }
 
 // DialConfig accepts a string in the AMQP URI format and a configuration for

--- a/examples_test.go
+++ b/examples_test.go
@@ -104,6 +104,36 @@ func ExampleDialTLS() {
 	log.Printf("conn: %v, err: %v", conn, err)
 }
 
+func ExampleDialwithTLSandExternalAuth() {
+	// This example assumes you enabled the rabbitmq-auth-mechanism-ssl plugin
+	// and your RabbitMQ server has TLS enabled
+
+	// The username will be read from the DN or CN fields of the certificate
+	// you provide, you can see the more detailed information provided here
+	// https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl#username-extraction-from-certificate
+
+	cfg := new(tls.Config)
+
+	// see at the top
+	cfg.RootCAs = x509.NewCertPool()
+
+	if ca, err := ioutil.ReadFile("testca/cacert.pem"); err == nil {
+		cfg.RootCAs.AppendCertsFromPEM(ca)
+	}
+
+	// Move the client cert and key to a location specific to your application
+	// and load them here.
+
+	if cert, err := tls.LoadX509KeyPair("client/cert.pem", "client/key.pem"); err == nil {
+		cfg.Certificates = append(cfg.Certificates, cert)
+	}
+
+	// If you don't supply the Auth method as EXTERNAL, connection wouldn't fail and you will be logged in as the guest user.
+	conn, err := amqp.Dial("amqps://server-name-from-certificate/", amqp.TLS(cfg), amqp.Auth([]amqp.Authentication{&amqp.ExternalAuth{}}))
+
+	log.Printf("conn: %v, err: %v", conn, err)
+}
+
 func ExampleChannel_Confirm_bridge() {
 	// This example acts as a bridge, shoveling all messages sent from the source
 	// exchange "log" to destination exchange "log".


### PR DESCRIPTION
I tried to finish the work inside the #121 as best I could seeing the recommendation here https://github.com/streadway/amqp/issues/355#issuecomment-540677849

Here is the summary of my work

* Made the changes requested in the code review #121 
* Used https://github.com/streadway/amqp/pull/121#issuecomment-577392074 to merge `DialTLS` and `DialExternalAuth` with `Dial`
* Added an example about how to use it
* Didn't deleted the other methods but can do so upon request

Best regards