### PR TITLE
fix #254 Channel.Publish blocks indefinitely

### DIFF
--- a/confirms.go
+++ b/confirms.go
@@ -1,13 +1,16 @@
 package amqp
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // confirms resequences and notifies one or multiple publisher confirmation listeners
 type confirms struct {
 	m         sync.Mutex
 	listeners []chan Confirmation
 	sequencer map[uint64]Confirmation
-	published uint64
+	published *uint64
 	expecting uint64
 }
 
@@ -15,7 +18,7 @@ type confirms struct {
 func newConfirms() *confirms {
 	return &confirms{
 		sequencer: map[uint64]Confirmation{},
-		published: 0,
+		published: new(uint64),
 		expecting: 1,
 	}
 }
@@ -29,11 +32,7 @@ func (c *confirms) Listen(l chan Confirmation) {
 
 // publish increments the publishing counter
 func (c *confirms) Publish() uint64 {
-	c.m.Lock()
-	defer c.m.Unlock()
-
-	c.published++
-	return c.published
+	return atomic.AddUint64(c.published, 1)
 }
 
 // confirm confirms one publishing, increments the expecting delivery tag, and
@@ -48,7 +47,7 @@ func (c *confirms) confirm(confirmation Confirmation) {
 
 // resequence confirms any out of order delivered confirmations
 func (c *confirms) resequence() {
-	for c.expecting <= c.published {
+	for c.expecting <= atomic.LoadUint64(c.published) {
 		sequenced, found := c.sequencer[c.expecting]
 		if !found {
 			return


### PR DESCRIPTION
I encountered a bug similar to this comment: https://github.com/streadway/amqp/issues/254#issuecomment-316401642

However, in a weak network environment, I get a deadlock after N+1 messages have been sent where N is the size of the buffered channel.

---

How to Reproduce:
- weak network enviroment (I was using `Network Link Conditioner` with `Very Bad Network` config)
- An external public network rabbitmq
- 10 goroutines sending messages to rabbitmq (I was using this library
https://github.com/shanbay/gobay/blob/v0.15.0/extensions/busext/amqp.go#L127)

Then it will deadlock.

---

The sequence of events is:
1. Receive an old message's ack -> `One()` -> `resequence()` -> `confirm()` send ack to channel
2. Receive another old message's ack -> `One() get lock` ->  `resequence()` -> `confirm()` send ack to channel -> block (channel buffer == 1) (and lock `confirms.m` is not released)
3. I am sending a message using `Publish` -> Failed to get lock

This time it will keep blocking; simply because the buffer is 1 but two ack are received at the same time (although I sent messages serially, we can indeed reproduce this extreme case).

---

I don't think publish needs to use the same lock as the other methods, it's just a self-incrementing. Even if the program is in `resequence()`, there may not be a problem with `Publish` at this point.