### PR TITLE
Fix AMQPLAIN authentication mechanism

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -6,6 +6,7 @@
 package amqp
 
 import (
+	"bytes"
 	"fmt"
 )
 
@@ -43,9 +44,14 @@ func (auth *AMQPlainAuth) Mechanism() string {
 	return "AMQPLAIN"
 }
 
-// Response returns the null character delimited encoding for the SASL PLAIN Mechanism.
+// Response returns an AMQP encoded credentials table, without the field table size.
 func (auth *AMQPlainAuth) Response() string {
-	return fmt.Sprintf("LOGIN:%sPASSWORD:%s", auth.Username, auth.Password)
+	var buf bytes.Buffer
+	table := Table{"LOGIN": auth.Username, "PASSWORD": auth.Password}
+	if err := writeTable(&buf, table); err != nil {
+		return ""
+	}
+	return buf.String()[4:]
 }
 
 // Finds the first mechanism preferred by the client that the server supports.


### PR DESCRIPTION
Fixes #514.

The current AMQPLAIN implementation does not work with `rabbitmq` out-of-the-box.

I could not find an official reference for that authentication mechanism. Looking at other implementations ([rust](https://github.com/CleverCloud/amq-protocol/blob/master/protocol/src/auth.rs#L45), [python](https://github.com/celery/py-amqp/blob/7300741f9fc202083e87abd10e1cb38c28efad92/amqp/sasl.py#L48)) it seems that AMQPLAIN uses an AMQP table (`LOGIN` and `PASSWORD` fields), omitting the table length.