### PR TITLE
fix:Stream(),The return value will not cancel

### DIFF
--- a/example_client_test.go
+++ b/example_client_test.go
@@ -191,7 +191,7 @@ func (session *Session) changeConnection(connection *amqp.Connection) {
 // and updates the channel listeners to reflect this.
 func (session *Session) changeChannel(channel *amqp.Channel) {
 	session.channel = channel
-	session.notifyChanClose = make(chan *amqp.Error)
+	session.notifyChanClose = make(chan *amqp.Error, 1)
 	session.notifyConfirm = make(chan amqp.Confirmation, 1)
 	session.channel.NotifyClose(session.notifyChanClose)
 	session.channel.NotifyPublish(session.notifyConfirm)


### PR DESCRIPTION
In the example, the return value of the Steam method amqp.delivery will not cancel.
When I restart Rabbitmq, amqp.delivery will not be canceled. Because this place is blocked