### PR TITLE
Add deprecation warning to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Consider using the github.com/rabbitmq/amqp091-go package instead.
 module github.com/streadway/amqp
 
 go 1.10


### PR DESCRIPTION
Following the instructions here https://go.dev/ref/mod#go-mod-file-module-deprecation
this will deprecate this module and point people to the supported version.

This will show up in linters and with `go mod` command as well as in the
pkg.go.dev website.
