### PR TITLE
Error because the url contains special characters

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -224,6 +224,10 @@ func DialUri(uri *URI) (*Connection, error) {
 	})
 }
 
+// DialUriConfig accepts a string in the AMQP URI format and a configuration for
+// the transport and connection setup, returning a new Connection.  Defaults to
+// a server heartbeat interval of 10 seconds and sets the initial read deadline
+// to 30 seconds.
 func DialUriConfig(uri *URI, config Config) (*Connection, error) {
 	var err error
 	var conn net.Conn


### PR DESCRIPTION
Error because the url contains special characters;
For example, amqp://guest:guest#123@localhost:5672/
Call amqp.dial (url), return error :parse "amqp://guest:guest": invalid port ":guest" after host
This error is caused by url.Parse.

Add a DailURI method that uses URI connections to pass in connection information without error if special characters are included